### PR TITLE
Add hint to allocate more memory if Elasticsearch crashes

### DIFF
--- a/content/en/admin/elasticsearch.md
+++ b/content/en/admin/elasticsearch.md
@@ -151,6 +151,23 @@ cd live
 RAILS_ENV=production bin/tootctl search deploy
 ```
 
+{{< hint style="info" >}}
+Creating Elasticsearch indicies could require more memory than the JVM (Java Virtual Machine) provides. If Elasticsearch crashes while creating indicies, try to allocate more memory.
+
+1. Create and open a file in the directory ```/etc/elasticsearch/jvm.options.d/``` (for example: ```nano /etc/elasticsearch/jvm.options.d/ram.options```)
+2. Add following text and edit the allocated memory to your needs. As a rule of thumb, Elasticsearch should use about 25%-50% of your available memory. Do not allocate more memory than available.
+```
+# Xms represents the initial size of total heap space
+# Xmx represents the maximum size of total heap space
+# Both values should be the same
+-Xms2048m
+-Xmx2048m
+```
+3. Save the file.
+4. Restart Elasticsearch using ```systemctl restart elasticsearch```.
+5. Retry creating Elasticsearch indicies. If Elasticsearch still crashes, try to set a higher number.
+{{< /hint >}}
+
 ## Search optimization for other languages
 ### Chinese search optimization {#chinese-search-optimization}
 


### PR DESCRIPTION
When creating Elasticsearch indicies, the process could crash if there is not enough memory allocated to the JVM runtime.

This commit adds a hint (and a step-by-step-guide) for administrators to try to allocate more memory to Elasticsearch if they're experiencing out-of-memory issues.

(I had a hard time troubleshooting this issue and I think others could benefit from this solution.)

Feedback and suggestions for improvement are welcome.